### PR TITLE
Add bash language server

### DIFF
--- a/bash/Dockerfile
+++ b/bash/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:current-alpine
+
+RUN npm install -g bash-language-server
+
+ENTRYPOINT ["/usr/local/bin/bash-language-server"]


### PR DESCRIPTION
Haven't done anything with the Makefile as I'm not entirely sure how
we'd want it.

Should there be a `bash-language-server` like target for each
language? `make` could just build all, but very few people will be
interested in building all images.