### PR TITLE
Go back to alpine

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -6,12 +6,14 @@ If you would like to add a language server to this repository, the requirements 
 - The image entrypoint is the language server executable and in "exec form",
 - The wrapper script follows ``wrapper-template.sh``,
 - Long-form options are used for all commands, where available,
-- The image uses the ``-slim`` variant of its base image, if possible,
-- If there is no language-specific image that is appropriate to use as a base, ``debian/stable-slim`` is to be used, and
+- The image uses the ``-alpine`` variant of its base image, if possible,
+- If there is no language-specific image that is appropriate to use as a base, ``alpine`` is to be used, and
 - There is a ``Makefile`` rule for building the image.
+
+In the case that Alpine based images are not available or inappropiate for some reason, ``debian-slim`` based images are preferred.
 
 It is not required to provide multiple versions, but it may be useful to have multiple images for different versions of the *language*, such as is the case with Elixir.  Your ``Dockerfile`` just needs to install the language server, and end with an ``ENTRYPOINT`` instruction that points to the language server itself, in "exec form" so that signals are passed to the language server.  Depending on whether the language server is controlled via stdio or a socket, you will need to specify appropriate options to ``docker run`` in the wrapper script.  (This would usually be ``--interactive`` for stdio, and either just ``--publish=`` or ``--publish-all=`` with ``EXPOSE`` instructions in the ``Dockerfile`` for sockets.)
 
 Long-form options are preferred to make scripts (including ``Dockerfile`` ``RUN`` instructions) clearer, without requiring the reader to look up several single-letter options.
 
-The "slim" base-images are preferred in the interest of saving space.
+The Alpine base-images are preferred in the interest of saving space.

--- a/bash/Dockerfile
+++ b/bash/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:current-slim
+FROM node:current-alpine
 
 RUN npm install --global bash-language-server
 

--- a/elixir/Dockerfile.1.10
+++ b/elixir/Dockerfile.1.10
@@ -1,6 +1,5 @@
-FROM elixir:1.10-slim
+FROM elixir:1.10-alpine
 WORKDIR /opt/elixir-ls
-RUN apt-get update && apt-get install --yes wget unzip
 RUN wget https://github.com/elixir-lsp/elixir-ls/releases/download/v0.7.0/elixir-ls-1.8.2.zip && \
     unzip elixir-ls-1.8.2.zip && \
     rm elixir-ls-1.8.2.zip && \

--- a/elixir/Dockerfile.1.11
+++ b/elixir/Dockerfile.1.11
@@ -1,6 +1,5 @@
-FROM elixir:1.11-slim
+FROM elixir:1.11-alpine
 WORKDIR /opt/elixir-ls && \
-RUN apt-get update && apt-get install --yes wget unzip
 RUN wget https://github.com/elixir-lsp/elixir-ls/releases/download/v0.7.0/elixir-ls-1.11.zip && \
     unzip elixir-ls-1.11.zip && \
     rm elixir-ls-1.11.zip && \


### PR DESCRIPTION
Worth saving a bit of space, but I've left a note about debian-slim
being preferred for the very few cases where alpine isn't an option.

And I've reformatted the file.